### PR TITLE
feat(autoencoder): add autoencoder and mnist classification

### DIFF
--- a/autoencoder/__main__.py
+++ b/autoencoder/__main__.py
@@ -1,0 +1,49 @@
+import numpy as np
+import torch
+from torchvision import transforms
+from autoencoder.utils import download_mnist_dataset, visualize_batch, visualize_image, visualize_after_decode, train, evaluate, stopwatch
+from autoencoder.autoencoder import AutoEncoder
+from torch import nn
+
+if __name__ == "__main__":
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    num_workers = 0
+    pin_memory = False
+
+    if device == "cuda":
+        num_workers = 4
+        pin_memory = True
+    print(f"Will be using {device} for training and testing")
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.1307,), (0.3081,))
+    ])
+
+    batch_size = 64
+    n_epochs = 30
+
+    train_set = download_mnist_dataset('mnist', True, transform=transform)
+    test_set = download_mnist_dataset('mnist', train=False, transform=transform)
+    train_loader = torch.utils.data.DataLoader(train_set, batch_size=64, shuffle=True, num_workers=num_workers,
+                                               pin_memory=pin_memory)
+    test_loader = torch.utils.data.DataLoader(test_set, batch_size=64, shuffle=True, num_workers=num_workers,
+                                              pin_memory=pin_memory)
+    # visualizes a part of the batch
+    visualize_batch(train_loader)
+    # visualizes an image in more detail
+    visualize_image(np.squeeze((next(iter(train_loader))[0])[0].numpy()))
+    encoder = AutoEncoder()
+    distance = nn.MSELoss()
+    criterion = nn.CrossEntropyLoss()
+    mse_multiplier = 0.5
+    cel_multiplier = 0.5
+    optimizer = torch.optim.Adam(encoder.parameters(), lr=0.002)
+    images, labels = next(iter(train_loader))
+    images = images.view(images.shape[0], -1)
+    encoder.to(device)
+    multipliers: tuple = (mse_multiplier, cel_multiplier)
+    print(
+        f"Training took {stopwatch(lambda: train(model=encoder, device=device, train_loader=train_loader, distance=distance, criterion=criterion, optimizer=optimizer, epochs=n_epochs))}s")
+    print(
+        f"Evaluation took {stopwatch(lambda: evaluate(model=encoder, device=device, test_loader=test_loader, criterion=criterion))}s")
+    visualize_after_decode(model=encoder, device=device, test_loader=test_loader)

--- a/autoencoder/autoencoder.py
+++ b/autoencoder/autoencoder.py
@@ -1,0 +1,34 @@
+from torch import nn
+
+
+class AutoEncoder(nn.Module):
+    def __init__(self):
+        super(AutoEncoder, self).__init__()
+        self.encoder = nn.Sequential(
+            nn.Conv2d(1, 4, kernel_size=5),
+            nn.Dropout2d(p=0.1),
+            nn.ReLU(True),
+            nn.Conv2d(4, 8, kernel_size=5),
+            nn.Dropout2d(p=0.1),
+            nn.ReLU(True),
+            nn.Flatten(start_dim=1),
+            nn.Linear(3200, 10)
+        )
+
+        self.softmax = nn.Softmax(dim=1)
+
+        self.decoder = nn.Sequential(
+            nn.Linear(10, 400),
+            nn.ReLU(True),
+            nn.Unflatten(1, (1, 20, 20)),
+            nn.Dropout2d(p=0.1),
+            nn.ConvTranspose2d(1, 10, kernel_size=5),
+            nn.ReLU(True),
+            nn.Dropout2d(p=0.1),
+            nn.ConvTranspose2d(10, 1, kernel_size=5)
+
+        )
+
+    def forward(self, x):
+        enc = self.encoder(x)
+        return enc, self.decoder(self.softmax(enc))

--- a/autoencoder/utils.py
+++ b/autoencoder/utils.py
@@ -1,0 +1,145 @@
+import time
+
+import torch.nn.functional
+from torch import max, no_grad
+from torchvision.datasets import MNIST
+from os import path
+import matplotlib.pyplot as plt
+import numpy as np
+from torch.nn.functional import softmax
+
+
+def download_mnist_dataset(root: str = 'data', train: bool = True, transform=None) -> MNIST:
+    return MNIST(root, train=train, download=not (path.exists(root) and path.isdir(root)), transform=transform)
+
+
+def visualize_batch(train_loader):
+    # obtain one batch of training images
+    dataiter = iter(train_loader)
+    images, labels = next(dataiter)
+    images = images.numpy()
+
+    fig = plt.figure(figsize=(25, 4))
+    for idx in np.arange(20):
+        ax = fig.add_subplot(2, 10, idx+1)
+        ax.imshow(np.squeeze(images[idx]), cmap='gray')
+        # print out the correct label for each image
+        # .item() gets the value contained in a Tensor
+        ax.set_title(str(labels[idx].item()))
+
+    plt.show()
+
+
+def visualize_image(img):
+    fig = plt.figure(figsize=(12, 12))
+    ax = fig.add_subplot(111)
+    ax.imshow(img, cmap='gray')
+    width, height = img.shape
+    thresh = img.max() / 2.5
+    for x in range(width):
+        for y in range(height):
+            val = round(img[x][y], 2) if img[x][y] != 0 else 0
+            ax.annotate(str(val), xy=(y, x),
+                        horizontalalignment='center',
+                        verticalalignment='center',
+                        color='white' if img[x][y] < thresh else 'black')
+    plt.show()
+
+
+def train(model, device, train_loader, distance, criterion, optimizer, epochs=50,
+          multipliers: tuple = (0.5, 0.5)):
+    model.train()  # prep model for training
+
+    mse_multiplier = multipliers[0]
+    cel_multiplier = multipliers[1]
+    for epoch in range(epochs):
+        # monitor training loss
+        mse_loss = 0.0
+        cel_loss = 0.0
+        for images, labels in train_loader:
+            images, labels = images.to(device), labels.to(device)
+            # clear the gradients of all optimized variables
+            optimizer.zero_grad()
+            # forward pass: compute predicted outputs by passing inputs to the model
+            out_enc, output = model(images)
+            # calculate the loss
+            loss_mse = distance(output, images)
+            loss_cel = criterion(out_enc, labels)
+            loss = (mse_multiplier * loss_mse) + (cel_multiplier * loss_cel)
+            # backward pass: compute gradient of the loss with respect to model parameters
+            loss.backward()
+            # perform a single optimization step (parameter update)
+            optimizer.step()
+            # update running training loss
+            mse_loss += loss_mse.item()
+            cel_loss += loss_cel.item()
+
+        print('Epoch: {} \tMSE Loss: {:.6f} \t Cross Entropy Loss {:.6}'.format(
+            epoch + 1,
+            mse_loss/len(train_loader),
+            cel_loss/len(train_loader)
+        ))
+    return
+
+
+def evaluate(model, device, test_loader, criterion):
+    test_loss = 0.0
+    class_correct = list(0. for _ in range(10))
+    class_total = list(0. for _ in range(10))
+
+    model.eval()  # prep model for *evaluation*
+
+    with no_grad():
+        for data, target in test_loader:
+            data, target = data.to(device), target.to(device)
+            # data = data.view(data.shape[0], -1)
+            output, _ = model(data)
+            prob = softmax(output, dim=1)
+            loss = criterion(output, target)
+            test_loss += loss.item() * data.size(0)
+            _, pred = torch.max(prob, dim=1)
+            pred.to(device)
+            correct = np.squeeze(pred.eq(target.data.view_as(pred)))
+            for i in range(16):
+                label = target.data[i]
+                class_correct[label] += correct[i].item()
+                class_total[label] += 1
+
+    # calculate and print avg test loss
+    test_loss = test_loss / len(test_loader.dataset)
+    print('Average Test Loss: {:.6f}\n'.format(test_loss))
+    for i in range(len(class_total)):
+        if class_total[i] > 0:
+            print('Test Accuracy of %5s: %2d%% (%2d/%2d)' % (
+                str(i), 100 * class_correct[i] / class_total[i],
+                np.sum(class_correct[i]), np.sum(class_total[i])))
+
+    print('\nTest Accuracy (Overall): %2d%% (%2d/%2d)' % (
+        100. * np.sum(class_correct) / np.sum(class_total),
+        np.sum(class_correct), np.sum(class_total)))
+    return
+
+
+def stopwatch(func):
+    start = time.time()
+    func()
+    end = time.time()
+    return f"{end - start}"
+
+
+def visualize_after_decode(model, test_loader, device):
+    model.eval()
+    img, labels = list(test_loader)[0]
+    img = img.to(device)
+    _, output = model(img)
+    inp = img[0:10, 0, :, :].squeeze().detach().cpu()
+    out = output[0:10, 0, :, :].squeeze().detach().cpu()
+
+    # Just some trick to concatenate first ten images next to each other
+    inp = inp.permute(1, 0, 2).reshape(28, -1).numpy()
+    out = out.permute(1, 0, 2).reshape(28, -1).numpy()
+    combined = np.vstack([inp, out])
+
+    plt.imshow(combined)
+    plt.show()
+


### PR DESCRIPTION
This adds an autoencoder to compress and reconstruct the mnist digit dataset. Alongside this it also classifies the decoded digits into their appropriate classes (0-9)

It uses 2 different loss functions and combines their output to construct the optimal neural network for both autoencoding and classification. 